### PR TITLE
Add habitat-core-plans-maintainers as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @habitat-sh/habitat-core-plans-maintainers


### PR DESCRIPTION
This way RFC PRs will notify people

Signed-off-by: Jon Bauman <5906042+baumanj@users.noreply.github.com>